### PR TITLE
Use pid of the spark-submit script as a part of the submit folder name

### DIFF
--- a/scripts/spark-submit
+++ b/scripts/spark-submit
@@ -8,13 +8,15 @@ fi
 
 setup-users
 
-mkdir /submit
+DIR_NAME=/submit.$$
 
-chown -R $SPARK_USER_NAME /submit
-chown -R $SPARK_GROUP_NAME /submit
+mkdir $DIR_NAME
+
+chown -R $SPARK_USER_NAME $DIR_NAME
+chown -R $SPARK_GROUP_NAME $DIR_NAME
 chown -R $SPARK_USER_NAME $SPARK_HOME
 chown -R $SPARK_GROUP_NAME $SPARK_HOME
 
-cd /submit
+cd $DIR_NAME
 
 exec sudo -E -u $SPARK_USER_NAME $SPARK_HOME/bin/spark-submit $*


### PR DESCRIPTION
In the documentation on submitting an application `spark-submit` is used as an entry-point, and consequently, the user is (most likely) running 1 spark-submit per container.
In my use case the workflow container is inherited from `dork` and it triggers multiple spark-submits depending on the particular job. This causes the problem since every spark-submit tries to put its state into `/submit` folder.

With this PR `submit` folder is suffixed with the PID of `spark-submit`. In the case described in the documentation the folder name will be `submit.1`. However, if multiple`spark-submit`s are being executed, there will be multiple folders, e.g. `submit.3`, `submit.35`, etc.